### PR TITLE
Update how-to-use.md

### DIFF
--- a/docs/how-to-use.md
+++ b/docs/how-to-use.md
@@ -226,7 +226,7 @@ On the cards in the large grid view, hover over the names for author information
 
 The Research Essays are grouped into categories:
 
-  - **An Introduction**: written by Project and invited scholars, these essay serve as introductory resources and provide overviews of the Edition and the manuscript itself (including its codicology, probable genesis, relationship to other genres of writing, and the identity of its anonymous author-practitioner).
+  - **An Introduction**: written by Project and invited scholars, these essays serve as introductory resources and provide overviews of the Edition and the manuscript itself (including its codicology, probable genesis, relationship to other genres of writing, and the identity of its anonymous author-practitioner).
 
   - **Art and Its Making**: materials, making, and meaning of art, and the training of artists.
   


### PR DESCRIPTION
corrected a typo:
changed "essay" to "essays" in this sentence:
written by Project and invited scholars, these essays serve as introductory resources and provide overviews of the Edition and the manuscript itself (including its codicology, probable genesis, relationship to other genres of writing, and the identity of its anonymous author-practitioner).